### PR TITLE
Solve missing tier 11

### DIFF
--- a/conf/character_services.conf.dist
+++ b/conf/character_services.conf.dist
@@ -114,7 +114,7 @@ CharacterServices.Cost.FactionChange = 250
 # Vanilla progression costs
 
 # Buying a progression tier, completes that progression tier. 
-# Example: buying TBC Tier 5 lets you to go Northrend and level to 80.
+# Example: buying TBC Tier 5 lets you go to Northrend and level to 80.
 
 # Molten Core
 CharacterServices.Cost.ProgressionTier.1 = 150

--- a/conf/character_services.conf.dist
+++ b/conf/character_services.conf.dist
@@ -43,7 +43,7 @@
 #        Description: Set the maximum tier level that can be purchased via the service
 #                    (Set to 0 to allow all tiers to be purchased up to the account's max)
 #        Default:     0 - No limit (use account's maximum tier)
-#                     1-16 - Specific maximum tier limit
+#                     1-18 - Specific maximum tier limit
 #
 
 CharacterServices.Enable = 1
@@ -53,7 +53,7 @@ CharacterServices.AppearanceChange.Enable = 0
 CharacterServices.RaceChange.Enable = 0
 CharacterServices.FactionChange.Enable = 0
 CharacterServices.ProgressionTier.Enable = 1
-CharacterServices.ProgressionTier.MaxApplicableTier = 16
+CharacterServices.ProgressionTier.MaxApplicableTier = 18
 
 #
 #    CharacterServices.DynamicCost.Enable
@@ -102,7 +102,7 @@ CharacterServices.Cost.FactionChange = 250
 #        PROGRESSION_PRE_TBC         = 8  (Pre-TBC)
 #        PROGRESSION_TBC_TIER_1      = 9  (Karazhan, Gruul's Lair, Magtheridon's Lair)
 #        PROGRESSION_TBC_TIER_2      = 10 (Serpentshrine Cavern, Tempest Keep)
-#        PROGRESSION_TBC_TIER_3      = 11 (Hyjal Summit, Black Temple)
+#        PROGRESSION_TBC_TIER_3      = 12 (Hyjal Summit, Black Temple)
 #        PROGRESSION_TBC_TIER_5      = 13 (Sunwell Plateau)
 #        PROGRESSION_WOTLK_TIER_1    = 14 (Naxxramas, Eye of Eternity, Obsidian Sanctum)
 #        PROGRESSION_WOTLK_TIER_2    = 15 (Ulduar)
@@ -112,6 +112,10 @@ CharacterServices.Cost.FactionChange = 250
 #
 
 # Vanilla progression costs
+
+# Buying a progression tier, completes that progression tier. 
+# Example: buying TBC Tier 5 lets you to go Northrend and level to 80.
+
 # Molten Core
 CharacterServices.Cost.ProgressionTier.1 = 150
 # Onyxia
@@ -126,7 +130,6 @@ CharacterServices.Cost.ProgressionTier.5 = 325
 CharacterServices.Cost.ProgressionTier.6 = 350
 # Naxx40
 CharacterServices.Cost.ProgressionTier.7 = 400
-
 # Pre-TBC
 CharacterServices.Cost.ProgressionTier.8 = 600
 
@@ -136,7 +139,7 @@ CharacterServices.Cost.ProgressionTier.9 = 1000
 # TBC Tier 2 (SSC, TK)
 CharacterServices.Cost.ProgressionTier.10 = 1250
 # TBC Tier 3 (Hyjal, BT)
-CharacterServices.Cost.ProgressionTier.11 = 1500
+CharacterServices.Cost.ProgressionTier.12 = 1500
 # TBC Tier 5 (Sunwell)
 CharacterServices.Cost.ProgressionTier.13 = 1700
 

--- a/conf/character_services.conf.dist
+++ b/conf/character_services.conf.dist
@@ -103,7 +103,6 @@ CharacterServices.Cost.FactionChange = 250
 #        PROGRESSION_TBC_TIER_1      = 9  (Karazhan, Gruul's Lair, Magtheridon's Lair)
 #        PROGRESSION_TBC_TIER_2      = 10 (Serpentshrine Cavern, Tempest Keep)
 #        PROGRESSION_TBC_TIER_3      = 11 (Hyjal Summit, Black Temple)
-#        PROGRESSION_TBC_TIER_4      = 12 (Zul'Aman)
 #        PROGRESSION_TBC_TIER_5      = 13 (Sunwell Plateau)
 #        PROGRESSION_WOTLK_TIER_1    = 14 (Naxxramas, Eye of Eternity, Obsidian Sanctum)
 #        PROGRESSION_WOTLK_TIER_2    = 15 (Ulduar)
@@ -138,8 +137,6 @@ CharacterServices.Cost.ProgressionTier.9 = 1000
 CharacterServices.Cost.ProgressionTier.10 = 1250
 # TBC Tier 3 (Hyjal, BT)
 CharacterServices.Cost.ProgressionTier.11 = 1500
-# TBC Tier 4 (ZA)
-CharacterServices.Cost.ProgressionTier.12 = 1600
 # TBC Tier 5 (Sunwell)
 CharacterServices.Cost.ProgressionTier.13 = 1700
 

--- a/data/sql/db-world/character_services_NPC.sql
+++ b/data/sql/db-world/character_services_NPC.sql
@@ -11,8 +11,9 @@ DELETE FROM `creature_template_model` WHERE `CreatureID` = @Entry;
 
 -- Insert the character services NPC
 -- Set to faction 35 (friendly to all) and proper flags for gossip interaction
-INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `rank`, `dmgschool`, `baseattacktime`, `rangeattacktime`, `unit_class`, `unit_flags`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `flags_extra`, `ScriptName`) VALUES
-(@Entry, @Name, 'Timeline Services', NULL, 0, 80, 80, 2, 35, 1, 0, 0, 2000, 0, 1, 0, 7, 138412032, 0, 0, 0, '', 0, 1, 0, 0, 1, 0, 2, 'character_services');
+INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `rank`, `dmgschool`, `baseattacktime`, `rangeattacktime`, 
+`unit_class`, `unit_flags`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
+(@Entry, @Name, 'Timeline Services', NULL, 0, 80, 80, 2, 35, 1, 0, 0, 2000, 0, 1, 0, 7, 138412032, 0, 0, 0, '', 0, 1, 0, 0, 1, 2, 'character_services');
 
 -- Set the display model - using Bronze Dragon Aspect model which fits the timeline theme
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES

--- a/src/CharacterServices.cpp
+++ b/src/CharacterServices.cpp
@@ -179,8 +179,11 @@ class CharacterServices : public CreatureScript
       // Only allow progression to the next tier (preventing skipping tiers)
       if (newTier > currentTier + 1)
       {
-        ChatHandler(player->GetSession()).PSendSysMessage("You can only purchase the next progression tier.");
-        return;
+        if (newTier != 11)
+        {
+          ChatHandler(player->GetSession()).PSendSysMessage("You can only purchase the next progression tier.");
+          return;
+        }
       }
       
       // Progress to the new tier
@@ -216,10 +219,8 @@ class CharacterServices : public CreatureScript
           return "Interface/Icons/achievement_boss_princemalchezaar_02";
         case PROGRESSION_TBC_TIER_2:
           return "Interface/Icons/achievement_boss_kael'thassunstrider_01";
-        case PROGRESSION_TBC_TIER_3:
-          return "Interface/Icons/achievement_boss_illidan";
         case PROGRESSION_TBC_TIER_4:
-          return "Interface/Icons/achievement_boss_zuljin";
+          return "Interface/Icons/achievement_boss_illidan";
         case PROGRESSION_TBC_TIER_5:
           return "Interface/Icons/achievement_boss_kiljaeden";
         case PROGRESSION_WOTLK_TIER_1:
@@ -263,8 +264,6 @@ class CharacterServices : public CreatureScript
           return "TBC Tier 1";
         case PROGRESSION_TBC_TIER_2:
           return "TBC Tier 2";
-        case PROGRESSION_TBC_TIER_3:
-          return "TBC Tier 3";
         case PROGRESSION_TBC_TIER_4:
           return "TBC Tier 4";
         case PROGRESSION_TBC_TIER_5:

--- a/src/CharacterServices.cpp
+++ b/src/CharacterServices.cpp
@@ -54,8 +54,13 @@ class CharacterServices : public CreatureScript
         // Only offer if there's an upgrade available
         if (accountMaxTier > currentTier)
         {
-          // Get the next progression tier name
-          uint8 nextTier = currentTier + 1;
+          uint8 nextTier = currentTier + 1; // Get the next progression tier name
+
+          if (currentTier == 10) // Special case for skipping TBC Tier 3 (Zul'Aman)
+          {
+            nextTier = 12; // Skip to TBC Tier 4
+          }
+            
           std::string nextTierName = GetProgressionTierName(nextTier);
           std::string tierIcon = GetTierIcon(nextTier);
           


### PR DESCRIPTION
Zul'Aman is no longer a progression tier.
When you can access this instance can now be configured by the user.
you now progress from TBC tier 3 to 5

'mechanic_immune_mask' also doesn't exist anymore in `creature_template`
this gave an sql error on startup, the npc this module uses doesn't have any immunities, so it could be removed.