### PR TITLE
Add ProgressionTier.RequireAccountUnlock config option

### DIFF
--- a/conf/character_services.conf.dist
+++ b/conf/character_services.conf.dist
@@ -47,6 +47,15 @@
 #        Default:     0 - No limit (use account's maximum tier)
 #                     1-18 - Specific maximum tier limit (excluding 11)
 #
+#    CharacterServices.ProgressionTier.RequireAccountUnlock
+#        Description: Require the tier to already be unlocked on the account (by some
+#                    character completing it normally) before it can be purchased here.
+#                    Set to 0 to let any character buy progression up to MaxApplicableTier
+#                    (or the top tier if MaxApplicableTier is 0) without prior unlock.
+#                    Tiers must still be purchased one at a time, in order.
+#        Default:     1 - Enabled (require account to have unlocked the tier)
+#                     0 - Disabled (no account-unlock requirement)
+#
 
 CharacterServices.Enable = 1
 
@@ -56,6 +65,7 @@ CharacterServices.RaceChange.Enable = 0
 CharacterServices.FactionChange.Enable = 0
 CharacterServices.ProgressionTier.Enable = 1
 CharacterServices.ProgressionTier.MaxApplicableTier = 0
+CharacterServices.ProgressionTier.RequireAccountUnlock = 1
 
 #
 #    CharacterServices.DynamicCost.Enable

--- a/src/CharacterServices.cpp
+++ b/src/CharacterServices.cpp
@@ -42,8 +42,15 @@ class CharacterServices : public CreatureScript
       if (sConfigMgr->GetOption<bool>("CharacterServices.ProgressionTier.Enable", false))
       {
         uint8 currentTier = sIndividualProgression->GetPlayerProgressionFromQuests(player);
-        uint8 accountMaxTier = sIndividualProgression->GetAccountProgression(player->GetSession()->GetAccountId());
         uint8 maxAllowedTier = sConfigMgr->GetOption<uint8>("CharacterServices.ProgressionTier.MaxApplicableTier", 0);
+        bool requireAccountUnlock = sConfigMgr->GetOption<bool>("CharacterServices.ProgressionTier.RequireAccountUnlock", true);
+
+        // When RequireAccountUnlock is true (default), the ceiling is the account's
+        // highest achieved tier. When false, any character may buy up to the top tier
+        // without another character having unlocked it first.
+        uint8 accountMaxTier = requireAccountUnlock
+          ? sIndividualProgression->GetAccountProgression(player->GetSession()->GetAccountId())
+          : PROGRESSION_WOTLK_TIER_5;
 
         // If MaxApplicableTier is set (non-zero), use it as a cap on the account's max tier
         if (maxAllowedTier > 0 && accountMaxTier > maxAllowedTier)
@@ -193,8 +200,14 @@ class CharacterServices : public CreatureScript
           return false;
 
       uint8 currentTier = sIndividualProgression->GetPlayerProgressionFromQuests(player);
-      uint8 accountMaxTier = sIndividualProgression->GetAccountProgression(player->GetSession()->GetAccountId());
       uint8 maxAllowedTier = sConfigMgr->GetOption<uint8>("CharacterServices.ProgressionTier.MaxApplicableTier", 0);
+      bool requireAccountUnlock = sConfigMgr->GetOption<bool>("CharacterServices.ProgressionTier.RequireAccountUnlock", true);
+
+      // When RequireAccountUnlock is true (default), cap purchases at the account's
+      // highest achieved tier. When false, the only ceiling is MaxApplicableTier (below).
+      uint8 accountMaxTier = requireAccountUnlock
+        ? sIndividualProgression->GetAccountProgression(player->GetSession()->GetAccountId())
+        : PROGRESSION_WOTLK_TIER_5;
 
       // Cap the account's max tier by the configured maximum, if any
       if (maxAllowedTier > 0)


### PR DESCRIPTION
## Summary

Makes the account-unlock requirement for progression tier purchases **optional** via a new config flag.

Currently, a character can only purchase a progression tier if some character on the account has already unlocked it normally (the service gates on `GetAccountProgression`). On servers that want the NPC to be a standalone way to advance, this requirement is undesirable.

## Change

New option: **`CharacterServices.ProgressionTier.RequireAccountUnlock`**

- Default `1` — preserves the existing behavior (tier must be unlocked on the account first).
- Set to `0` — any character may purchase progression up to `MaxApplicableTier` (or the top tier if `MaxApplicableTier` is 0) without a prior account unlock.

Tiers must still be purchased **one at a time, in order** — the no-skip and current-tier checks are untouched. The `MaxApplicableTier` cap continues to apply in both modes.

## Files

- `src/CharacterServices.cpp` — both the gossip-menu offer and the purchase-validation path read the new flag; when disabled, the effective ceiling becomes the top tier instead of the account's achieved tier.
- `conf/character_services.conf.dist` — documents and defines the new option (default `1`).

## Backwards compatibility

Fully backwards compatible — the option defaults to the current behavior, so existing servers see no change unless they opt in.